### PR TITLE
AnyLogger.subscribersの処理が冗長なのを改善

### DIFF
--- a/lib/any_logger.rb
+++ b/lib/any_logger.rb
@@ -16,6 +16,6 @@ module AnyLogger
   end
 
   def self.subscribers
-    config.config[:subscribers]
+    config.subscribers
   end
 end


### PR DESCRIPTION
Configuration#subscribersメソッドが使えるので、そちらに変更