### PR TITLE
ActionView::LogSubscriberをdetachしたときに、デフォルトでattachされているイベントをdetachする

### DIFF
--- a/lib/any_logger/configuration/event.rb
+++ b/lib/any_logger/configuration/event.rb
@@ -6,6 +6,12 @@ module AnyLogger
       Detach = Struct.new(:organizer, :event)
       Attach = Struct.new(:organizer, :event, :subscriber)
 
+      DEFAULT_ATTACHED_EVENTS = {
+        action_view: [:render_template, :render_layout]
+      }
+
+      private_constant :DEFAULT_ATTACHED_EVENTS
+
       def swap(organizer, event, subscriber = nil, &block)
         @organizer = organizer
         @event = event
@@ -22,6 +28,12 @@ module AnyLogger
 
         push_detach_to_subscriptions
         detach_from_event
+      end
+
+      def detaches_default_attached_for(organizer)
+        return unless DEFAULT_ATTACHED_EVENTS[organizer]
+
+        DEFAULT_ATTACHED_EVENTS[organizer].each { |event| detach(organizer, event) }
       end
 
       def attach(organizer, event, subscriber = nil, &block)

--- a/lib/any_logger/configuration/log_subscriber.rb
+++ b/lib/any_logger/configuration/log_subscriber.rb
@@ -43,6 +43,7 @@ module AnyLogger
 
         push_detach_to_subscriptions
         @detach_target.detach_from(@organizer)
+        event.detaches_default_attached_for(@organizer)
       end
 
       def attach(organizer, subscriber)
@@ -63,6 +64,10 @@ module AnyLogger
 
       private def validate_detach_target_is_set
         raise KeyError, "#{@organizer}'s default subscriber not found" unless @detach_target
+      end
+
+      private def event
+        AnyLogger.config.event
       end
     end
   end


### PR DESCRIPTION
#23 
ActionView以外にも対応できるよう、拡張性を持たせておく。